### PR TITLE
aw8624: add haptic level adjustment

### DIFF
--- a/drivers/misc/aw8624_haptic/aw8624.c
+++ b/drivers/misc/aw8624_haptic/aw8624.c
@@ -698,9 +698,20 @@ static int aw8624_haptic_set_repeat_wav_seq(struct aw8624 *aw8624,
 	return 0;
 }
 
+static unsigned char aw8624_haptic_set_level(struct aw8624 *aw8624, int gain)
+{
+    int val = 80;
+
+    val = aw8624->ulevel * gain / 128;
+    if (val > 255)
+        val = 255;
+
+    return val;
+}
+
 static int aw8624_haptic_set_gain(struct aw8624 *aw8624, unsigned char gain)
 {
-	aw8624_i2c_write(aw8624, AW8624_REG_DATDBG, gain);
+	aw8624_i2c_write(aw8624, AW8624_REG_DATDBG, aw8624_haptic_set_level(aw8624, gain));
 	return 0;
 }
 
@@ -2068,6 +2079,7 @@ static int aw8624_haptic_init(struct aw8624 *aw8624)
 	}
 
 	aw8624->activate_mode = aw8624->info.mode;
+	aw8624->ulevel = 128;
 	aw8624->osc_cali_run = 0;
 	ret = aw8624_i2c_read(aw8624, AW8624_REG_WAVSEQ1, &reg_val);
 	aw8624->index = reg_val & 0x7F;
@@ -3278,6 +3290,37 @@ static ssize_t aw8624_gain_store(struct device *dev,
 	return count;
 }
 
+static ssize_t aw8624_ulevel_show(struct device *dev,
+				struct device_attribute *attr, char *buf)
+{
+	struct aw8624 *aw8624 = dev_get_drvdata(dev);
+	return snprintf(buf, PAGE_SIZE, "0x%02x\n", aw8624->gain);
+}
+
+static ssize_t aw8624_ulevel_store(struct device *dev,
+				struct device_attribute *attr, const char *buf,
+				size_t count)
+{
+	struct aw8624 *aw8624 = dev_get_drvdata(dev);
+	unsigned int val = 0;
+	int rc = 0;
+
+	rc = kstrtouint(buf, 0, &val);
+	if (rc < 0)
+		return rc;
+
+	if (val < 0 || val > 128)
+		val = 128;
+
+	pr_info("%s: value=%d\n", __FUNCTION__, val);
+
+	mutex_lock(&aw8624->lock);
+	aw8624->ulevel = val;
+	aw8624_haptic_set_gain(aw8624, aw8624->gain);
+	mutex_unlock(&aw8624->lock);
+	return count;
+}
+
 static ssize_t aw8624_seq_show(struct device *dev,
 			       struct device_attribute *attr, char *buf)
 {
@@ -3922,6 +3965,8 @@ static DEVICE_ATTR(index, 0644, aw8624_index_show,
 		   aw8624_index_store);
 static DEVICE_ATTR(gain, 0644, aw8624_gain_show,
 		   aw8624_gain_store);
+static DEVICE_ATTR(ulevel, 0644, aw8624_ulevel_show,
+                   aw8624_ulevel_store);
 static DEVICE_ATTR(seq, 0644, aw8624_seq_show, aw8624_seq_store);
 static DEVICE_ATTR(loop, 0644, aw8624_loop_show,
 		   aw8624_loop_store);
@@ -3964,6 +4009,7 @@ static struct attribute *aw8624_vibrator_attributes[] = {
 	&dev_attr_activate_mode.attr,
 	&dev_attr_index.attr,
 	&dev_attr_gain.attr,
+	&dev_attr_ulevel.attr,
 	&dev_attr_seq.attr,
 	&dev_attr_loop.attr,
 	&dev_attr_rtp.attr,

--- a/drivers/misc/aw8624_haptic/aw8624.h
+++ b/drivers/misc/aw8624_haptic/aw8624.h
@@ -346,6 +346,7 @@ struct aw8624 {
 	int index;
 	int vmax;
 	int gain;
+	int ulevel;
 	int f0_value;
 	unsigned char level;
 


### PR DESCRIPTION
* Inspired by "leds-qpnp-haptics: allow user adjustment" (https://github.com/flar2/OnePlus6/commit/2122b595e6152660c1cb7fdba8ef2940b91592b5)
* earlier implementaion (https://github.com/xzr467706992/android_kernel_oneplus_sm8250/commit/c3e400cc51c62c248baef6b3836f3c6aee6c615a)

Co-authored-by: LibXZR <xzr467706992@163.com>
Co-authored-by: azrim <mirzaspc@gmail.com>
[azrim: adapt to aw8624]
Signed-off-by: azrim <mirzaspc@gmail.com>